### PR TITLE
Allow metric to apply filters by default

### DIFF
--- a/src/Concerns/AppliesDefaultFilters.php
+++ b/src/Concerns/AppliesDefaultFilters.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Nemrutco\Filterable\Concerns;
+
+interface AppliesDefaultFilters
+{
+}


### PR DESCRIPTION
I've added an interface `AppliesDefaultFilters` that will allow a metric to apply filters by default if none provided.

For instance:

```php

namespace App\Nova\Metrics;

use App\Nova\Filters\DateRange;
use Nemrutco\Filterable\Concerns\AppliesDefaultFilters;

class ExampleMetric extends Partition implements AppliesDefaultFilters
{
    use Filterable;

    // ...

    public function filters()
    {
        return [
            new DateRange,
        ];
    }
}
```

And the filter of DateRange would have a `default` method:

```php
public function default(): string
{
    return sprintf(
        '%s to %s',
        now()->startOfMonth()->format('Y-m-d'),
        now()->endOfMonth()->format('Y-m-d')
    );
}
```

In the example above, the `ExampleMetric` will apply the `DateRange` filter's default value on it's initial load.